### PR TITLE
Removed forced UPPERCASE of title element

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ function plugin(opt = {}) {
         children: [
           {
             type: 'text',
-            value: (title || type).trim().toUpperCase(),
+            value: (title || type).trim(),
           },
         ],
         data: { hProperties: { className: [`${className}-title`] } },


### PR DESCRIPTION
Don't necessarily want the title capitalized in every case. Removed the `toUpperCase()`